### PR TITLE
リクエスト専用のIssueフォームを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-ja.yaml
+++ b/.github/ISSUE_TEMPLATE/request-ja.yaml
@@ -1,0 +1,38 @@
+name: リクエスト
+description: ロゴの追加依頼
+title: "[Request] "
+labels: ["request", "enhancement"]
+assignees:
+  - SAWARATSUKI
+body:
+  - type: markdown
+    attributes:
+      value: |
+        issuesに投稿してください。確認次第作成します。
+        個人のスケジュールにより対応できない場合もあります。数日かかる場合もあります。
+
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: 重複チェック
+      description: 他のIssueと内容が重複していないことを確認してください。
+      options:
+        - label: 確認しました
+          required: true
+
+  - type: input
+    id: service-name
+    attributes:
+      label: サービス名
+      description: 追加を希望するサービスの名称
+      placeholder: 例) GitHub
+    validations:
+      required: true
+
+  - type: textarea
+    id: comment
+    attributes:
+      label: コメント・補足
+      description: 画像がある場合はこちらに添付してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/request.yaml
+++ b/.github/ISSUE_TEMPLATE/request.yaml
@@ -1,0 +1,38 @@
+name: Request
+description: Request a logo that's not here.
+title: "[Request] "
+labels: ["request", "enhancement"]
+assignees:
+  - SAWARATSUKI
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please post it in the issues. We'll create it once confirmed.
+        Depending on individual schedules, we may not be able to respond immediately. It may take several days.
+
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: Check for duplicates
+      description: Check that the Issue has not been duplicated.
+      options:
+        - label: Checked
+          required: true
+
+  - type: input
+    id: service-name
+    attributes:
+      label: Service Name
+      description: Name of service for which you would like to add a logo.
+      placeholder: ex. GitHub
+    validations:
+      required: true
+
+  - type: textarea
+    id: comment
+    attributes:
+      label: Comment
+      description: Please attach images to this area.
+    validations:
+      required: false


### PR DESCRIPTION
イシュマロがすごいことになっていたので、もしよければ

## 概要
- リクエスト用のIssueテンプレートを作成しました。
- 文言類は README.mdから拝借しました。

## 参考
- [Issue フォームの構文](https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)