### PR TITLE
Add Japanese README link

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,4 +1,4 @@
-[English README](https://github.com/SAWARATSUKI/ServiceLogos/blob/master/README.md)
+[English README](README.md) | [日本語 README](README-ja.md)
 # ServiceLogos
 こんにちは、こんばんは
 ここはさわらつきが作った各サービスのロゴをアップロードするリポジトリです。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[English README](https://github.com/SAWARATSUKI/ServiceLogos/blob/master/README.md)
+[English README](README.md) | [日本語 README](README-ja.md)
 
 # ServiceLogos
 Hello, good morning, good evening.


### PR DESCRIPTION
#164 のPRです。

README.mdに日本語READMEのリンクを追加しました。
またforkした場合絶対パスでは、URLを書き直さなければならないという問題があると考えたため相対パスに変更しました。

以下の変更を行いました：

- 英語のREADMEへのリンクを絶対パスから相対パスに変更
- 日本語版READMEへのリンク（README-ja.md）を新たに追加


調整が必要な部分があれば教えてください。

よろしくお願いします！
