### PR TITLE
Add Issue template for correction request.

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix-request-ja.yaml
+++ b/.github/ISSUE_TEMPLATE/fix-request-ja.yaml
@@ -1,7 +1,7 @@
 name: 修正依頼
 description: ロゴの修正依頼
 title: "[Fix] "
-labels: ["enhancement"]
+labels: ["fix"]
 assignees:
   - SAWARATSUKI
 body:
@@ -34,7 +34,7 @@ body:
     attributes:
       label: 修正内容
       description: 修正内容を具体的に記載してください
-      placeholder: 例) Githubの日本語表記を「ギットハブ」に修正
+      placeholder: 例) Githubの日本語表記を「ぎっとはぶ」から「ギットハブ」に修正
     validations:
       required: true
       

--- a/.github/ISSUE_TEMPLATE/fix-request-ja.yaml
+++ b/.github/ISSUE_TEMPLATE/fix-request-ja.yaml
@@ -1,0 +1,47 @@
+name: 修正依頼
+description: ロゴの修正依頼
+title: "[Fix] "
+labels: ["enhancement"]
+assignees:
+  - SAWARATSUKI
+body:
+  - type: markdown
+    attributes:
+      value: |
+        issuesに投稿してください。確認次第作成します。
+        個人のスケジュールにより対応できない場合もあります。数日かかる場合もあります。
+
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: 重複チェック
+      description: 他のIssueと内容が重複していないことを確認してください。
+      options:
+        - label: 確認しました
+          required: true
+
+  - type: input
+    id: service-name
+    attributes:
+      label: サービス名
+      description: 修正を希望するサービスの名称
+      placeholder: 例) GitHub
+    validations:
+      required: true
+  
+  - type: input
+    id: revision-detail
+    attributes:
+      label: 修正内容
+      description: 修正内容を具体的に記載してください
+      placeholder: 例) Githubの日本語表記を「ギットハブ」に修正
+    validations:
+      required: true
+      
+  - type: textarea
+    id: comment
+    attributes:
+      label: コメント・補足
+      description: 修正する根拠がある場合はこちらに記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/fix-request.yaml
+++ b/.github/ISSUE_TEMPLATE/fix-request.yaml
@@ -1,7 +1,7 @@
 name: Modification
 description: Request a logo modification.
 title: "[Fix] "
-labels: ["enhancement"]
+labels: ["fix"]
 assignees:
   - SAWARATSUKI
 body:
@@ -34,7 +34,7 @@ body:
     attributes:
       label: Description of modifications
       description: Please describe the modification in detail
-      placeholder: ex. Corrected Japanese spelling of Github to "ギットハブ".
+      placeholder: ex. Corrected Japanese spelling of Github from "ぎっとはぶ" to "ギットハブ.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/fix-request.yaml
+++ b/.github/ISSUE_TEMPLATE/fix-request.yaml
@@ -1,0 +1,47 @@
+name: Modification
+description: Request a logo modification.
+title: "[Fix] "
+labels: ["enhancement"]
+assignees:
+  - SAWARATSUKI
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please post it in the issues. We'll create it once confirmed.
+        Depending on individual schedules, we may not be able to respond immediately. It may take several days.
+
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: Check for duplicates
+      description: Check that the Issue has not been duplicated.
+      options:
+        - label: Checked
+          required: true
+
+  - type: input
+    id: service-name
+    attributes:
+      label: Service Name
+      description: Name of the service for which you are requesting a change.
+      placeholder: ex. GitHub
+    validations:
+      required: true
+
+  - type: input
+    id: revision-detail
+    attributes:
+      label: Description of modifications
+      description: Please describe the modification in detail
+      placeholder: ex. Corrected Japanese spelling of Github to "ギットハブ".
+    validations:
+      required: true
+
+  - type: textarea
+    id: comment
+    attributes:
+      label: Comment
+      description: If you have a basis for modification, please describe it here.
+    validations:
+      required: false


### PR DESCRIPTION
# 概要
修正リクエスト用のissueテンプレートを作成.

# 理由
ロゴのミスなどにより修正を依頼するisuueが存在しており、今後も発生する可能性があることを考慮した場合に予めテンプレートを用意しておいた方が管理が楽であると考えるため。

# 課題点
現在使用付与しているラベルは暫定的に"enhancement"であるが"fix"などのラベルに変更したい