### PR TITLE
2024/4/25 午前８時 時点でのREADME画像一覧の修正

### DIFF
--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -59,16 +59,18 @@ issuesに投稿する場合必ずリクエストタグを付けて投稿して�
 | Cobol          | <img src="/Cobol/Cobol.png" width="100"/> |
 | Crowdstrike    | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
 | Figma          | <img src="/Figma/Figma.png" width="100"/> |
+| FORTRAN        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
+| Flipper Zero   | <img src="/Fripper Zero/Flipper Zero.png" width="100"/> |
 | Flutter        | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| Github         | <img src="/Github/Github.png" width="100"/> |
-| Gitlab         | <img src="/Gitlab/Gitlab.png" width="100"/> |
+| GitHub         | <img src="/GitHub/GitHub.png" width="100"/> |
+| GitLab         | <img src="/GitLab/GitLab.png" width="100"/> |
 | Gnuemacs       | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
 | Go             | <img src="/Go/Golang.png" width="100"/> |
 | Haskell        | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
 | Hono           | <img src="/Hono/Hono.png" width="100"/> |
 | Html           | <img src="/Html/HTML.png" width="100"/> |
 | Htmx           | <img src="/Htmx/htmx.png" width="100"/> |
-| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> |
+| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
 | Java           | <img src="/Java/Java.png" width="100"/> |
 | Juniper        | <img src="/Juniper/Juniper.png" width="100"/> |
 | Kotlin         | <img src="/Kotlin/Kotlin.png" width="100"/> |
@@ -90,6 +92,9 @@ issuesに投稿する場合必ずリクエストタグを付けて投稿して�
 | Swift          | <img src="/Swift/Swift.png" width="100"/> |
 | Tailwindcss    | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
 | Teamspeak      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
+| Twitter        | <img src="/Twitter/Twitter.png" width="100"/> |
+| TypeScript     | <img src="/TypeScript/TypeScript.png" width="100"/> |
+| Ubuntu         | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
 | UnityBlender   | <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
 | Vim            | <img src="/Vim/VIM.png" width="100"/> |
 | Vite           | <img src="/Vite/Vite.png" width="100"/> |

--- a/docs/README-zhHans.md
+++ b/docs/README-zhHans.md
@@ -63,15 +63,17 @@
 | Crowdstrike    | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
 | Figma          | <img src="/Figma/Figma.png" width="100"/> |
 | Flutter        | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| Github         | <img src="/Github/Github.png" width="100"/> |
-| Gitlab         | <img src="/Gitlab/Gitlab.png" width="100"/> |
+| FORTRAN        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
+| Flipper Zero   | <img src="/Fripper Zero/Flipper Zero.png" width="100"/> |
+| GitHub         | <img src="/GitHub/GitHub.png" width="100"/> |
+| GitLab         | <img src="/GitLab/GitLab.png" width="100"/> |
 | Gnuemacs       | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
 | Go             | <img src="/Go/Golang.png" width="100"/> |
 | Haskell        | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
 | Hono           | <img src="/Hono/Hono.png" width="100"/> |
 | Html           | <img src="/Html/HTML.png" width="100"/> |
 | Htmx           | <img src="/Htmx/htmx.png" width="100"/> |
-| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> |
+| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
 | Java           | <img src="/Java/Java.png" width="100"/> |
 | Juniper        | <img src="/Juniper/Juniper.png" width="100"/> |
 | Kotlin         | <img src="/Kotlin/Kotlin.png" width="100"/> |
@@ -93,6 +95,9 @@
 | Swift          | <img src="/Swift/Swift.png" width="100"/> |
 | Tailwindcss    | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
 | Teamspeak      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
+| Twitter        | <img src="/Twitter/Twitter.png" width="100"/> |
+| TypeScript     | <img src="/TypeScript/TypeScript.png" width="100"/> |
+| Ubuntu         | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
 | UnityBlender   | <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
 | Vim            | <img src="/Vim/VIM.png" width="100"/> |
 | Vite           | <img src="/Vite/Vite.png" width="100"/> |

--- a/docs/README-zhHans.md
+++ b/docs/README-zhHans.md
@@ -62,9 +62,9 @@
 | Cobol          | <img src="/Cobol/Cobol.png" width="100"/> |
 | Crowdstrike    | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
 | Figma          | <img src="/Figma/Figma.png" width="100"/> |
-| Flutter        | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
 | FORTRAN        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
 | Flipper Zero   | <img src="/Fripper Zero/Flipper Zero.png" width="100"/> |
+| Flutter        | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
 | GitHub         | <img src="/GitHub/GitHub.png" width="100"/> |
 | GitLab         | <img src="/GitLab/GitLab.png" width="100"/> |
 | Gnuemacs       | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,16 +57,18 @@ If you would like to sell your product officially, please send a [Direct message
 | Cobol          | <img src="/Cobol/Cobol.png" width="100"/> |
 | Crowdstrike    | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
 | Figma          | <img src="/Figma/Figma.png" width="100"/> |
+| FORTRAN        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
+| Flipper Zero   | <img src="/Fripper Zero/Flipper Zero.png" width="100"/> |
 | Flutter        | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| Github         | <img src="/Github/Github.png" width="100"/> |
-| Gitlab         | <img src="/Gitlab/Gitlab.png" width="100"/> |
+| GitHub         | <img src="/GitHub/GitHub.png" width="100"/> |
+| GitLab         | <img src="/GitLab/GitLab.png" width="100"/> |
 | Gnuemacs       | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
 | Go             | <img src="/Go/Golang.png" width="100"/> |
 | Haskell        | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
 | Hono           | <img src="/Hono/Hono.png" width="100"/> |
 | Html           | <img src="/Html/HTML.png" width="100"/> |
 | Htmx           | <img src="/Htmx/htmx.png" width="100"/> |
-| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> |
+| IamSeries      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
 | Java           | <img src="/Java/Java.png" width="100"/> |
 | Juniper        | <img src="/Juniper/Juniper.png" width="100"/> |
 | Kotlin         | <img src="/Kotlin/Kotlin.png" width="100"/> |
@@ -88,6 +90,9 @@ If you would like to sell your product officially, please send a [Direct message
 | Swift          | <img src="/Swift/Swift.png" width="100"/> |
 | Tailwindcss    | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
 | Teamspeak      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
+| Twitter        | <img src="/Twitter/Twitter.png" width="100"/> |
+| TypeScript     | <img src="/TypeScript/TypeScript.png" width="100"/> |
+| Ubuntu         | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
 | UnityBlender   | <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
 | Vim            | <img src="/Vim/VIM.png" width="100"/> |
 | Vite           | <img src="/Vite/Vite.png" width="100"/> |


### PR DESCRIPTION
README に以下の画像を追加しました：
- FORTRAN
- Flipper Zero
- IamDesigner!/English
- Twitter
- TypeScript
- Ubuntu

ただし、次の問題を解決する必要があります：
- [ ] #308
- [ ] #305 及び [GitLab](https://about.gitlab.com/press/press-kit/)