### PR TITLE
use python script to generate images table

### DIFF
--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -50,60 +50,61 @@ issuesに投稿する場合必ずリクエストタグを付けて投稿して�
 
 ## 日本語訳：
 
-| 名前 | 画像 |
+| Name | Image |
 |-------------------------------|--------|
-| [Angular](/Angular/)          | <img src="/Angular/Angular.png" width="100"/> <img src="/Angular/Angular_Old.png" width="100"/> |
-| [ArchLinux](/ArchLinux/)      | <img src="/ArchLinux/ArchLinux.png" width="100"/> |
-| [C#](/C%23/)                  | <img src="/C%23/C%23%20Purple.png" width="100"/> <img src="/C%23/C%23.png" width="100"/> |
-| [C++](/C%2B%2B/)              | <img src="/C%2B%2B/C%2B%2B.png" width="100"/> |
-| [C,C#,C++](/C,C%23,C%2B%2B/)  | <img src="/C,C%23,C%2B%2B/All.png" width="100"/> |
-| [C](/C/)                      | <img src="/C/C.png" width="100"/> |
-| [Clion](/Clion/)              | <img src="/Clion/Clion.png" width="100"/> |
-| [Cloudflare](/Cloudflare/)    | <img src="/Cloudflare/Cloudflare.png" width="100"/> |
-| [Cobol](/Cobol/)              | <img src="/Cobol/Cobol.png" width="100"/> |
-| [Crowdstrike](/Crowdstrike/)  | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
-| [Figma](/Figma/)              | <img src="/Figma/Figma.png" width="100"/> |
-| [FORTRAN](/FORTRAN/)        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
-| [FlipperZero](/FlipperZero/)| <img src="/FlipperZero/FlipperZero.png" width="100"/> |
-| [Flutter](/Flutter/)          | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| [GitHub](/GitHub/)            | <img src="/GitHub/GitHub.png" width="100"/> |
-| [GitLab](/GitLab/)            | <img src="/GitLab/GitLab.png" width="100"/> |
-| [Gnuemacs](/Gnuemacs/)        | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
-| [Go](/Go/)                    | <img src="/Go/Golang.png" width="100"/> |
-| [Haskell](/Haskell/)          | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
-| [Hono](/Hono/)                | <img src="/Hono/Hono.png" width="100"/> |
-| [Html](/Html/)                | <img src="/Html/HTML.png" width="100"/> |
-| [Htmx](/Htmx/)                | <img src="/Htmx/htmx.png" width="100"/> |
-| [IamSeries](/IamSeries/)      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
-| [Java](/Java/)                | <img src="/Java/Java.png" width="100"/> |
-| [Juniper](/Juniper/)          | <img src="/Juniper/Juniper.png" width="100"/> |
-| [Kotlin](/Kotlin/)            | <img src="/Kotlin/Kotlin.png" width="100"/> |
-| [Laravel](/Laravel/)          | <img src="/Laravel/Laravel.png" width="100"/> |
-| [Mui](/Mui/)                  | <img src="/Mui/Mui.png" width="100"/> |
-| [Next.js](/Next.js/)          | <img src="/Next.js/Next.js.png" width="100"/> |
-| [Node.js](/Node.js/)          | <img src="/Node.js/Node.js.png" width="100"/> |
-| [Photoshop](/Photoshop/)      | <img src="/Photoshop/Photoshop.png" width="100"/> |
-| [Python](/Python/)            | <img src="/Python/Python.png" width="100"/> |
-| [Qwik.js](/Qwik.js/)          | <img src="/Qwik.js/Qwik.png" width="100"/> |
-| [RaspberryPi](/RaspberryPi/)  | <img src="/RaspberryPi/Raspberry%20Pi.png" width="100"/> |
-| [React](/React/)              | <img src="/React/React.png" width="100"/> |
-| [RhineLab](/RhineLab/)        | <img src="/RhineLab/RhineLab.png" width="100"/> |
-| [Rider](/Rider/)              | <img src="/Rider/Rider.png" width="100"/> |
-| [Rstudio](/Rstudio/)          | <img src="/Rstudio/RStudio.png" width="100"/> |
-| [Ruby](/Ruby/)                | <img src="/Ruby/Ruby.png" width="100"/> |
-| [Rust](/Rust/)                | <img src="/Rust/Rust.png" width="100"/> |
-| [Streamloots](/Streamloots/)  | <img src="/Streamloots/Streamloots.png" width="100"/> |
-| [Swift](/Swift/)              | <img src="/Swift/Swift.png" width="100"/> |
-| [Tailwindcss](/Tailwindcss/)  | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
-| [Teamspeak](/Teamspeak/)      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
-| [Twitter](/Twitter/)          | <img src="/Twitter/Twitter.png" width="100"/> |
-| [TypeScript](/TypeScript/)    | <img src="/TypeScript/TypeScript.png" width="100"/> |
-| [Ubuntu](/Ubuntu/)            | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
-| [UnityBlender](/UnityBlender/)| <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
-| [Vim](/Vim/)                  | <img src="/Vim/VIM.png" width="100"/> |
-| [Vite](/Vite/)                | <img src="/Vite/Vite.png" width="100"/> |
-| [Voicemod](/Voicemod/)        | <img src="/Voicemod/Voicemod.png" width="100"/> |
-| [Vrchat](/Vrchat/)            | <img src="/Vrchat/VRChat.png" width="100"/> |
-| [Vue](/Vue/)                  | <img src="/Vue/Vue.png" width="100"/> |
-| [Wallhack](/Wallhack/)        | <img src="/Wallhack/WALLHACK.png" width="100"/> |
-| [X](/X/)                      | <img src="/X/X.png" width="100"/> |
+| 404Notfound  | <img src="../404Notfound/NotFound.png" width="100" /> |
+| Angular      | <img src="../Angular/Angular.png" width="100" /> <img src="../Angular/Angular_Old.png" width="100" /> |
+| ArchLinux    | <img src="../ArchLinux/ArchLinux.png" width="100" /> |
+| C#           | <img src="../C%23/C%23%20Purple.png" width="100" /> <img src="../C%23/C%23.png" width="100" /> |
+| C++          | <img src="../C%2B%2B/C%2B%2B.png" width="100" /> |
+| C,C#,C++     | <img src="../C%2CC%23%2CC%2B%2B/All.png" width="100" /> |
+| C            | <img src="../C/C.png" width="100" /> |
+| Clion        | <img src="../Clion/Clion.png" width="100" /> |
+| Cloudflare   | <img src="../Cloudflare/Cloudflare.png" width="100" /> |
+| Cobol        | <img src="../Cobol/Cobol.png" width="100" /> |
+| Crowdstrike  | <img src="../Crowdstrike/CroudStrike.png" width="100" /> |
+| FORTRAN      | <img src="../FORTRAN/FORTRAN.png" width="100" /> |
+| Figma        | <img src="../Figma/Figma.png" width="100" /> |
+| FlipperZero  | <img src="../FlipperZero/FlipperZero.png" width="100" /> |
+| Flutter      | <img src="../Flutter/FlutterTransparent.png" width="100" /> |
+| GitHub       | <img src="../GitHub/GitHub.png" width="100" /> |
+| GitLab       | <img src="../GitLab/GitLab.png" width="100" /> |
+| Gnuemacs     | <img src="../Gnuemacs/GNUEmacs.png" width="100" /> |
+| Go           | <img src="../Go/Golang.png" width="100" /> |
+| Haskell      | <img src="../Haskell/Haskell%20%24.png" width="100" /> <img src="../Haskell/Haskell.png" width="100" /> |
+| Hono         | <img src="../Hono/Hono.png" width="100" /> |
+| Html         | <img src="../Html/HTML.png" width="100" /> |
+| Htmx         | <img src="../Htmx/htmx.png" width="100" /> |
+| IamSeries    | <img src="../IamSeries/IamDesigner%21.png" width="100" /> <img src="../IamSeries/IamDesigner%21English.png" width="100" /> <img src="../IamSeries/IamProgrammer%21.png" width="100" /> <img src="../IamSeries/IamProgrammerEnglish.png" width="100" /> |
+| Java         | <img src="../Java/Java.png" width="100" /> |
+| Juniper      | <img src="../Juniper/Juniper.png" width="100" /> |
+| Kotlin       | <img src="../Kotlin/Kotlin.png" width="100" /> <img src="../Kotlin/Kotlin_New.png" width="100" /> |
+| Laravel      | <img src="../Laravel/Laravel.png" width="100" /> |
+| Mui          | <img src="../Mui/Mui.png" width="100" /> |
+| Next.js      | <img src="../Next.js/Next.js.png" width="100" /> |
+| Node.js      | <img src="../Node.js/Node.js.png" width="100" /> |
+| Photoshop    | <img src="../Photoshop/Photoshop.png" width="100" /> |
+| Python       | <img src="../Python/Python.png" width="100" /> |
+| Qwik.js      | <img src="../Qwik.js/Qwik.png" width="100" /> |
+| RaspberryPi  | <img src="../RaspberryPi/Raspberry%20Pi.png" width="100" /> |
+| React        | <img src="../React/React.png" width="100" /> |
+| RhineLab     | <img src="../RhineLab/RhineLab.png" width="100" /> |
+| Rider        | <img src="../Rider/Rider.png" width="100" /> |
+| Rstudio      | <img src="../Rstudio/RStudio.png" width="100" /> |
+| Ruby         | <img src="../Ruby/Ruby.png" width="100" /> |
+| Rust         | <img src="../Rust/Rust.png" width="100" /> |
+| Streamloots  | <img src="../Streamloots/Streamloots.png" width="100" /> |
+| Swift        | <img src="../Swift/Swift.png" width="100" /> |
+| Tailwindcss  | <img src="../Tailwindcss/Tailwindcss6.png" width="100" /> |
+| Teamspeak    | <img src="../Teamspeak/TeamSpeak.png" width="100" /> |
+| Twitter      | <img src="../Twitter/Twitter.png" width="100" /> |
+| TypeScript   | <img src="../TypeScript/TypeScript.png" width="100" /> |
+| Ubuntu       | <img src="../Ubuntu/Ubuntu.png" width="100" /> |
+| UnityBlender | <img src="../UnityBlender/UnityBlenderT.png" width="100" /> |
+| Vim          | <img src="../Vim/VIM.png" width="100" /> |
+| Vite         | <img src="../Vite/Vite.png" width="100" /> |
+| Voicemod     | <img src="../Voicemod/Voicemod.png" width="100" /> |
+| Vrchat       | <img src="../Vrchat/VRChat.png" width="100" /> |
+| Vue          | <img src="../Vue/Vue.png" width="100" /> |
+| Wallhack     | <img src="../Wallhack/WALLHACK.png" width="100" /> |
+| X            | <img src="../X/X.png" width="100" /> |

--- a/docs/README-zhHans.md
+++ b/docs/README-zhHans.md
@@ -53,60 +53,61 @@
 
 ## 图片集：
 
-| 名称 | 图片 |
+| Name | Image |
 |-------------------------------|--------|
-| [Angular](/Angular/)          | <img src="/Angular/Angular.png" width="100"/> <img src="/Angular/Angular_Old.png" width="100"/> |
-| [ArchLinux](/ArchLinux/)      | <img src="/ArchLinux/ArchLinux.png" width="100"/> |
-| [C#](/C%23/)                  | <img src="/C%23/C%23%20Purple.png" width="100"/> <img src="/C%23/C%23.png" width="100"/> |
-| [C++](/C%2B%2B/)              | <img src="/C%2B%2B/C%2B%2B.png" width="100"/> |
-| [C,C#,C++](/C,C%23,C%2B%2B/)  | <img src="/C,C%23,C%2B%2B/All.png" width="100"/> |
-| [C](/C/)                      | <img src="/C/C.png" width="100"/> |
-| [Clion](/Clion/)              | <img src="/Clion/Clion.png" width="100"/> |
-| [Cloudflare](/Cloudflare/)    | <img src="/Cloudflare/Cloudflare.png" width="100"/> |
-| [Cobol](/Cobol/)              | <img src="/Cobol/Cobol.png" width="100"/> |
-| [Crowdstrike](/Crowdstrike/)  | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
-| [Figma](/Figma/)              | <img src="/Figma/Figma.png" width="100"/> |
-| [FORTRAN](/FORTRAN/)        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
-| [FlipperZero](/FlipperZero/)| <img src="/FlipperZero/FlipperZero.png" width="100"/> |
-| [Flutter](/Flutter/)          | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| [GitHub](/GitHub/)            | <img src="/GitHub/GitHub.png" width="100"/> |
-| [GitLab](/GitLab/)            | <img src="/GitLab/GitLab.png" width="100"/> |
-| [Gnuemacs](/Gnuemacs/)        | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
-| [Go](/Go/)                    | <img src="/Go/Golang.png" width="100"/> |
-| [Haskell](/Haskell/)          | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
-| [Hono](/Hono/)                | <img src="/Hono/Hono.png" width="100"/> |
-| [Html](/Html/)                | <img src="/Html/HTML.png" width="100"/> |
-| [Htmx](/Htmx/)                | <img src="/Htmx/htmx.png" width="100"/> |
-| [IamSeries](/IamSeries/)      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
-| [Java](/Java/)                | <img src="/Java/Java.png" width="100"/> |
-| [Juniper](/Juniper/)          | <img src="/Juniper/Juniper.png" width="100"/> |
-| [Kotlin](/Kotlin/)            | <img src="/Kotlin/Kotlin.png" width="100"/> |
-| [Laravel](/Laravel/)          | <img src="/Laravel/Laravel.png" width="100"/> |
-| [Mui](/Mui/)                  | <img src="/Mui/Mui.png" width="100"/> |
-| [Next.js](/Next.js/)          | <img src="/Next.js/Next.js.png" width="100"/> |
-| [Node.js](/Node.js/)          | <img src="/Node.js/Node.js.png" width="100"/> |
-| [Photoshop](/Photoshop/)      | <img src="/Photoshop/Photoshop.png" width="100"/> |
-| [Python](/Python/)            | <img src="/Python/Python.png" width="100"/> |
-| [Qwik.js](/Qwik.js/)          | <img src="/Qwik.js/Qwik.png" width="100"/> |
-| [RaspberryPi](/RaspberryPi/)  | <img src="/RaspberryPi/Raspberry%20Pi.png" width="100"/> |
-| [React](/React/)              | <img src="/React/React.png" width="100"/> |
-| [RhineLab](/RhineLab/)        | <img src="/RhineLab/RhineLab.png" width="100"/> |
-| [Rider](/Rider/)              | <img src="/Rider/Rider.png" width="100"/> |
-| [Rstudio](/Rstudio/)          | <img src="/Rstudio/RStudio.png" width="100"/> |
-| [Ruby](/Ruby/)                | <img src="/Ruby/Ruby.png" width="100"/> |
-| [Rust](/Rust/)                | <img src="/Rust/Rust.png" width="100"/> |
-| [Streamloots](/Streamloots/)  | <img src="/Streamloots/Streamloots.png" width="100"/> |
-| [Swift](/Swift/)              | <img src="/Swift/Swift.png" width="100"/> |
-| [Tailwindcss](/Tailwindcss/)  | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
-| [Teamspeak](/Teamspeak/)      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
-| [Twitter](/Twitter/)          | <img src="/Twitter/Twitter.png" width="100"/> |
-| [TypeScript](/TypeScript/)    | <img src="/TypeScript/TypeScript.png" width="100"/> |
-| [Ubuntu](/Ubuntu/)            | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
-| [UnityBlender](/UnityBlender/)| <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
-| [Vim](/Vim/)                  | <img src="/Vim/VIM.png" width="100"/> |
-| [Vite](/Vite/)                | <img src="/Vite/Vite.png" width="100"/> |
-| [Voicemod](/Voicemod/)        | <img src="/Voicemod/Voicemod.png" width="100"/> |
-| [Vrchat](/Vrchat/)            | <img src="/Vrchat/VRChat.png" width="100"/> |
-| [Vue](/Vue/)                  | <img src="/Vue/Vue.png" width="100"/> |
-| [Wallhack](/Wallhack/)        | <img src="/Wallhack/WALLHACK.png" width="100"/> |
-| [X](/X/)                      | <img src="/X/X.png" width="100"/> |
+| 404Notfound  | <img src="../404Notfound/NotFound.png" width="100" /> |
+| Angular      | <img src="../Angular/Angular.png" width="100" /> <img src="../Angular/Angular_Old.png" width="100" /> |
+| ArchLinux    | <img src="../ArchLinux/ArchLinux.png" width="100" /> |
+| C#           | <img src="../C%23/C%23%20Purple.png" width="100" /> <img src="../C%23/C%23.png" width="100" /> |
+| C++          | <img src="../C%2B%2B/C%2B%2B.png" width="100" /> |
+| C,C#,C++     | <img src="../C%2CC%23%2CC%2B%2B/All.png" width="100" /> |
+| C            | <img src="../C/C.png" width="100" /> |
+| Clion        | <img src="../Clion/Clion.png" width="100" /> |
+| Cloudflare   | <img src="../Cloudflare/Cloudflare.png" width="100" /> |
+| Cobol        | <img src="../Cobol/Cobol.png" width="100" /> |
+| Crowdstrike  | <img src="../Crowdstrike/CroudStrike.png" width="100" /> |
+| FORTRAN      | <img src="../FORTRAN/FORTRAN.png" width="100" /> |
+| Figma        | <img src="../Figma/Figma.png" width="100" /> |
+| FlipperZero  | <img src="../FlipperZero/FlipperZero.png" width="100" /> |
+| Flutter      | <img src="../Flutter/FlutterTransparent.png" width="100" /> |
+| GitHub       | <img src="../GitHub/GitHub.png" width="100" /> |
+| GitLab       | <img src="../GitLab/GitLab.png" width="100" /> |
+| Gnuemacs     | <img src="../Gnuemacs/GNUEmacs.png" width="100" /> |
+| Go           | <img src="../Go/Golang.png" width="100" /> |
+| Haskell      | <img src="../Haskell/Haskell%20%24.png" width="100" /> <img src="../Haskell/Haskell.png" width="100" /> |
+| Hono         | <img src="../Hono/Hono.png" width="100" /> |
+| Html         | <img src="../Html/HTML.png" width="100" /> |
+| Htmx         | <img src="../Htmx/htmx.png" width="100" /> |
+| IamSeries    | <img src="../IamSeries/IamDesigner%21.png" width="100" /> <img src="../IamSeries/IamDesigner%21English.png" width="100" /> <img src="../IamSeries/IamProgrammer%21.png" width="100" /> <img src="../IamSeries/IamProgrammerEnglish.png" width="100" /> |
+| Java         | <img src="../Java/Java.png" width="100" /> |
+| Juniper      | <img src="../Juniper/Juniper.png" width="100" /> |
+| Kotlin       | <img src="../Kotlin/Kotlin.png" width="100" /> <img src="../Kotlin/Kotlin_New.png" width="100" /> |
+| Laravel      | <img src="../Laravel/Laravel.png" width="100" /> |
+| Mui          | <img src="../Mui/Mui.png" width="100" /> |
+| Next.js      | <img src="../Next.js/Next.js.png" width="100" /> |
+| Node.js      | <img src="../Node.js/Node.js.png" width="100" /> |
+| Photoshop    | <img src="../Photoshop/Photoshop.png" width="100" /> |
+| Python       | <img src="../Python/Python.png" width="100" /> |
+| Qwik.js      | <img src="../Qwik.js/Qwik.png" width="100" /> |
+| RaspberryPi  | <img src="../RaspberryPi/Raspberry%20Pi.png" width="100" /> |
+| React        | <img src="../React/React.png" width="100" /> |
+| RhineLab     | <img src="../RhineLab/RhineLab.png" width="100" /> |
+| Rider        | <img src="../Rider/Rider.png" width="100" /> |
+| Rstudio      | <img src="../Rstudio/RStudio.png" width="100" /> |
+| Ruby         | <img src="../Ruby/Ruby.png" width="100" /> |
+| Rust         | <img src="../Rust/Rust.png" width="100" /> |
+| Streamloots  | <img src="../Streamloots/Streamloots.png" width="100" /> |
+| Swift        | <img src="../Swift/Swift.png" width="100" /> |
+| Tailwindcss  | <img src="../Tailwindcss/Tailwindcss6.png" width="100" /> |
+| Teamspeak    | <img src="../Teamspeak/TeamSpeak.png" width="100" /> |
+| Twitter      | <img src="../Twitter/Twitter.png" width="100" /> |
+| TypeScript   | <img src="../TypeScript/TypeScript.png" width="100" /> |
+| Ubuntu       | <img src="../Ubuntu/Ubuntu.png" width="100" /> |
+| UnityBlender | <img src="../UnityBlender/UnityBlenderT.png" width="100" /> |
+| Vim          | <img src="../Vim/VIM.png" width="100" /> |
+| Vite         | <img src="../Vite/Vite.png" width="100" /> |
+| Voicemod     | <img src="../Voicemod/Voicemod.png" width="100" /> |
+| Vrchat       | <img src="../Vrchat/VRChat.png" width="100" /> |
+| Vue          | <img src="../Vue/Vue.png" width="100" /> |
+| Wallhack     | <img src="../Wallhack/WALLHACK.png" width="100" /> |
+| X            | <img src="../X/X.png" width="100" /> |

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,60 +48,61 @@ If you would like to sell your product officially, please send a [Direct message
 
 ## image :
 
-| Name | Images |
+| Name | Image |
 |-------------------------------|--------|
-| [Angular](/Angular/)          | <img src="/Angular/Angular.png" width="100"/> <img src="/Angular/Angular_Old.png" width="100"/> |
-| [ArchLinux](/ArchLinux/)      | <img src="/ArchLinux/ArchLinux.png" width="100"/> |
-| [C#](/C%23/)                  | <img src="/C%23/C%23%20Purple.png" width="100"/> <img src="/C%23/C%23.png" width="100"/> |
-| [C++](/C%2B%2B/)              | <img src="/C%2B%2B/C%2B%2B.png" width="100"/> |
-| [C,C#,C++](/C,C%23,C%2B%2B/)  | <img src="/C,C%23,C%2B%2B/All.png" width="100"/> |
-| [C](/C/)                      | <img src="/C/C.png" width="100"/> |
-| [Clion](/Clion/)              | <img src="/Clion/Clion.png" width="100"/> |
-| [Cloudflare](/Cloudflare/)    | <img src="/Cloudflare/Cloudflare.png" width="100"/> |
-| [Cobol](/Cobol/)              | <img src="/Cobol/Cobol.png" width="100"/> |
-| [Crowdstrike](/Crowdstrike/)  | <img src="/Crowdstrike/CroudStrike.png" width="100"/> |
-| [Figma](/Figma/)              | <img src="/Figma/Figma.png" width="100"/> |
-| [FORTRAN](/FORTRAN/)        | <img src="/FORTRAN/FORTRAN.png" width="100"/> |
-| [FlipperZero](/FlipperZero/)| <img src="/FlipperZero/FlipperZero.png" width="100"/> |
-| [Flutter](/Flutter/)          | <img src="/Flutter/FlutterTransparent.png" width="100"/> |
-| [GitHub](/GitHub/)            | <img src="/GitHub/GitHub.png" width="100"/> |
-| [GitLab](/GitLab/)            | <img src="/GitLab/GitLab.png" width="100"/> |
-| [Gnuemacs](/Gnuemacs/)        | <img src="/Gnuemacs/GNUEmacs.png" width="100"/> |
-| [Go](/Go/)                    | <img src="/Go/Golang.png" width="100"/> |
-| [Haskell](/Haskell/)          | <img src="/Haskell/Haskell%20$.png" width="100"/> <img src="/Haskell/Haskell.png" width="100"/> |
-| [Hono](/Hono/)                | <img src="/Hono/Hono.png" width="100"/> |
-| [Html](/Html/)                | <img src="/Html/HTML.png" width="100"/> |
-| [Htmx](/Htmx/)                | <img src="/Htmx/htmx.png" width="100"/> |
-| [IamSeries](/IamSeries/)      | <img src="/IamSeries/IamProgrammer!.png" width="100"/> <img src="/IamSeries/IamProgrammerEnglish.png" width="100"/> <img src="/IamSeries/IamDesigner!.png" width="100"/> <img src="/IamSeries/IamDesigner!English.png" width="100"/> |
-| [Java](/Java/)                | <img src="/Java/Java.png" width="100"/> |
-| [Juniper](/Juniper/)          | <img src="/Juniper/Juniper.png" width="100"/> |
-| [Kotlin](/Kotlin/)            | <img src="/Kotlin/Kotlin.png" width="100"/> |
-| [Laravel](/Laravel/)          | <img src="/Laravel/Laravel.png" width="100"/> |
-| [Mui](/Mui/)                  | <img src="/Mui/Mui.png" width="100"/> |
-| [Next.js](/Next.js/)          | <img src="/Next.js/Next.js.png" width="100"/> |
-| [Node.js](/Node.js/)          | <img src="/Node.js/Node.js.png" width="100"/> |
-| [Photoshop](/Photoshop/)      | <img src="/Photoshop/Photoshop.png" width="100"/> |
-| [Python](/Python/)            | <img src="/Python/Python.png" width="100"/> |
-| [Qwik.js](/Qwik.js/)          | <img src="/Qwik.js/Qwik.png" width="100"/> |
-| [RaspberryPi](/RaspberryPi/)  | <img src="/RaspberryPi/Raspberry%20Pi.png" width="100"/> |
-| [React](/React/)              | <img src="/React/React.png" width="100"/> |
-| [RhineLab](/RhineLab/)        | <img src="/RhineLab/RhineLab.png" width="100"/> |
-| [Rider](/Rider/)              | <img src="/Rider/Rider.png" width="100"/> |
-| [Rstudio](/Rstudio/)          | <img src="/Rstudio/RStudio.png" width="100"/> |
-| [Ruby](/Ruby/)                | <img src="/Ruby/Ruby.png" width="100"/> |
-| [Rust](/Rust/)                | <img src="/Rust/Rust.png" width="100"/> |
-| [Streamloots](/Streamloots/)  | <img src="/Streamloots/Streamloots.png" width="100"/> |
-| [Swift](/Swift/)              | <img src="/Swift/Swift.png" width="100"/> |
-| [Tailwindcss](/Tailwindcss/)  | <img src="/Tailwindcss/Tailwindcss6.png" width="100"/> |
-| [Teamspeak](/Teamspeak/)      | <img src="/Teamspeak/TeamSpeak.png" width="100"/> |
-| [Twitter](/Twitter/)          | <img src="/Twitter/Twitter.png" width="100"/> |
-| [TypeScript](/TypeScript/)    | <img src="/TypeScript/TypeScript.png" width="100"/> |
-| [Ubuntu](/Ubuntu/)            | <img src="/Ubuntu/Ubuntu.png" width="100"/> |
-| [UnityBlender](/UnityBlender/)| <img src="/UnityBlender/UnityBlenderT.png" width="100"/> |
-| [Vim](/Vim/)                  | <img src="/Vim/VIM.png" width="100"/> |
-| [Vite](/Vite/)                | <img src="/Vite/Vite.png" width="100"/> |
-| [Voicemod](/Voicemod/)        | <img src="/Voicemod/Voicemod.png" width="100"/> |
-| [Vrchat](/Vrchat/)            | <img src="/Vrchat/VRChat.png" width="100"/> |
-| [Vue](/Vue/)                  | <img src="/Vue/Vue.png" width="100"/> |
-| [Wallhack](/Wallhack/)        | <img src="/Wallhack/WALLHACK.png" width="100"/> |
-| [X](/X/)                      | <img src="/X/X.png" width="100"/> |
+| 404Notfound  | <img src="../404Notfound/NotFound.png" width="100" /> |
+| Angular      | <img src="../Angular/Angular.png" width="100" /> <img src="../Angular/Angular_Old.png" width="100" /> |
+| ArchLinux    | <img src="../ArchLinux/ArchLinux.png" width="100" /> |
+| C#           | <img src="../C%23/C%23%20Purple.png" width="100" /> <img src="../C%23/C%23.png" width="100" /> |
+| C++          | <img src="../C%2B%2B/C%2B%2B.png" width="100" /> |
+| C,C#,C++     | <img src="../C%2CC%23%2CC%2B%2B/All.png" width="100" /> |
+| C            | <img src="../C/C.png" width="100" /> |
+| Clion        | <img src="../Clion/Clion.png" width="100" /> |
+| Cloudflare   | <img src="../Cloudflare/Cloudflare.png" width="100" /> |
+| Cobol        | <img src="../Cobol/Cobol.png" width="100" /> |
+| Crowdstrike  | <img src="../Crowdstrike/CroudStrike.png" width="100" /> |
+| FORTRAN      | <img src="../FORTRAN/FORTRAN.png" width="100" /> |
+| Figma        | <img src="../Figma/Figma.png" width="100" /> |
+| FlipperZero  | <img src="../FlipperZero/FlipperZero.png" width="100" /> |
+| Flutter      | <img src="../Flutter/FlutterTransparent.png" width="100" /> |
+| GitHub       | <img src="../GitHub/GitHub.png" width="100" /> |
+| GitLab       | <img src="../GitLab/GitLab.png" width="100" /> |
+| Gnuemacs     | <img src="../Gnuemacs/GNUEmacs.png" width="100" /> |
+| Go           | <img src="../Go/Golang.png" width="100" /> |
+| Haskell      | <img src="../Haskell/Haskell%20%24.png" width="100" /> <img src="../Haskell/Haskell.png" width="100" /> |
+| Hono         | <img src="../Hono/Hono.png" width="100" /> |
+| Html         | <img src="../Html/HTML.png" width="100" /> |
+| Htmx         | <img src="../Htmx/htmx.png" width="100" /> |
+| IamSeries    | <img src="../IamSeries/IamDesigner%21.png" width="100" /> <img src="../IamSeries/IamDesigner%21English.png" width="100" /> <img src="../IamSeries/IamProgrammer%21.png" width="100" /> <img src="../IamSeries/IamProgrammerEnglish.png" width="100" /> |
+| Java         | <img src="../Java/Java.png" width="100" /> |
+| Juniper      | <img src="../Juniper/Juniper.png" width="100" /> |
+| Kotlin       | <img src="../Kotlin/Kotlin.png" width="100" /> <img src="../Kotlin/Kotlin_New.png" width="100" /> |
+| Laravel      | <img src="../Laravel/Laravel.png" width="100" /> |
+| Mui          | <img src="../Mui/Mui.png" width="100" /> |
+| Next.js      | <img src="../Next.js/Next.js.png" width="100" /> |
+| Node.js      | <img src="../Node.js/Node.js.png" width="100" /> |
+| Photoshop    | <img src="../Photoshop/Photoshop.png" width="100" /> |
+| Python       | <img src="../Python/Python.png" width="100" /> |
+| Qwik.js      | <img src="../Qwik.js/Qwik.png" width="100" /> |
+| RaspberryPi  | <img src="../RaspberryPi/Raspberry%20Pi.png" width="100" /> |
+| React        | <img src="../React/React.png" width="100" /> |
+| RhineLab     | <img src="../RhineLab/RhineLab.png" width="100" /> |
+| Rider        | <img src="../Rider/Rider.png" width="100" /> |
+| Rstudio      | <img src="../Rstudio/RStudio.png" width="100" /> |
+| Ruby         | <img src="../Ruby/Ruby.png" width="100" /> |
+| Rust         | <img src="../Rust/Rust.png" width="100" /> |
+| Streamloots  | <img src="../Streamloots/Streamloots.png" width="100" /> |
+| Swift        | <img src="../Swift/Swift.png" width="100" /> |
+| Tailwindcss  | <img src="../Tailwindcss/Tailwindcss6.png" width="100" /> |
+| Teamspeak    | <img src="../Teamspeak/TeamSpeak.png" width="100" /> |
+| Twitter      | <img src="../Twitter/Twitter.png" width="100" /> |
+| TypeScript   | <img src="../TypeScript/TypeScript.png" width="100" /> |
+| Ubuntu       | <img src="../Ubuntu/Ubuntu.png" width="100" /> |
+| UnityBlender | <img src="../UnityBlender/UnityBlenderT.png" width="100" /> |
+| Vim          | <img src="../Vim/VIM.png" width="100" /> |
+| Vite         | <img src="../Vite/Vite.png" width="100" /> |
+| Voicemod     | <img src="../Voicemod/Voicemod.png" width="100" /> |
+| Vrchat       | <img src="../Vrchat/VRChat.png" width="100" /> |
+| Vue          | <img src="../Vue/Vue.png" width="100" /> |
+| Wallhack     | <img src="../Wallhack/WALLHACK.png" width="100" /> |
+| X            | <img src="../X/X.png" width="100" /> |

--- a/docs/generate-images-table.py
+++ b/docs/generate-images-table.py
@@ -1,0 +1,40 @@
+import os
+import urllib.parse
+
+
+def main():
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+
+    # Get all directories in the parent directory
+    data: dict[str, list[str]] = {}
+    for d in os.listdir(os.path.join(current_dir, "..")):
+        if not os.path.isdir(os.path.join(current_dir, "..", d)):
+            continue
+        if d.startswith("."):
+            continue
+            
+        # Get all png files in the directory
+        files = [f for f in os.listdir(os.path.join(current_dir, "..", d)) if f.endswith(".png")]
+        if not files:
+            continue
+
+        data[d] = files
+    
+    # Generate markdown table
+    columnWidth = max(len(name) for name in data.keys())
+
+    markdown = "| Name | Image |\n"
+    markdown += '|-------------------------------|--------|\n'
+
+    for name, images in data.items():
+        markdown += f"| {name.ljust(columnWidth)} | "
+        for image in images:
+            url = urllib.parse.quote(f"../{name}/{image}")
+            markdown += f'<img src="{url}" width="100" /> '
+        markdown += "|\n"
+    
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Thanks for your kawaii logos!

I wrote a simple Python script to generate markdown tables, using relative paths and URL encoding, so that images can be correctly rendered in markdown readers like GitLab, Gitea, VSCode, etc.

```bash
python docs/generate-images-table.py
```